### PR TITLE
Fix building just one image with --all flag

### DIFF
--- a/bap-builder/DockerMode.go
+++ b/bap-builder/DockerMode.go
@@ -41,7 +41,10 @@ func buildAllDockerImages(contextManager ContextManager) error {
 			logger.Warn("Bug: multiple Dockerfile present for same image name %s", imageName)
 			continue
 		}
-		return buildSingleDockerImage(imageName, dockerfilePath[0])
+		err = buildSingleDockerImage(imageName, dockerfilePath[0])
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling during the Docker image building process to capture and return errors more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->